### PR TITLE
Add docName method to IsDocType class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## [0.2.1.0] - 2026-03-13
+
+### Added
+
+- Added `docName` method to `IsDocType` class to get the document ID.
+
 ## [0.2.0.0] - 2025-04-12
 
 ### Changed

--- a/erpnext-api-client.cabal
+++ b/erpnext-api-client.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.6
 
 name:                erpnext-api-client
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            Generic API client library for ERPNext
 description:         This is a Haskell API client for ERPNext. It aims to be a light-weight library based on http-client and user-provided record types.
 homepage:            https://github.com/schoettl/erpnext-api-client

--- a/src/ERPNext/Client.hs
+++ b/src/ERPNext/Client.hs
@@ -43,7 +43,10 @@ import ERPNext.Client.Helper (urlEncode)
 -- Each DocType has a unique name but there can still be multiple
 -- „views“ (i.e. records types) for one DocType.
 class IsDocType a where
+  -- | The DocType name, e.g. „Sales Order“.
   docTypeName :: Text
+  -- | The document identifier - called @name@ in ERPNext.
+  docName :: a -> Text
 
 {-|
   Get a list of all documents of a given DocType.


### PR DESCRIPTION
With this we have a generic way to access the doc ID. Use case example:

```hs
-- | Get the ERPNext URL for a document given by name.
-- The base URL is extracted from app settings.
getDocTypeUrl :: forall a. IsDocType a => AppSettings -> Text -> Text
getDocTypeUrl settings name = fromMaybe "" (stripSuffix "/api" (appERPNextBaseUrl settings)) <> "/desk/" <> toLower (docTypeName @a) <> "/" <> name

-- | Get the ERPNext URL for a given document.
-- The base URL is extracted from app settings.
getDocTypeUrl' :: forall a. IsDocType a => AppSettings -> a -> Text
getDocTypeUrl' settings doc = getDocTypeUrl @a settings (docName doc)

```

Note `(docName doc)` in the last line of the code.